### PR TITLE
add four starting events

### DIFF
--- a/Scenes/StoryCards/lab_elevator.tscn
+++ b/Scenes/StoryCards/lab_elevator.tscn
@@ -1,20 +1,22 @@
-[gd_scene load_steps=7 format=3 uid="uid://da3vfbn325gkk"]
+[gd_scene load_steps=7 format=3 uid="uid://6bk3cflxuf7g"]
 
-[ext_resource type="Script" uid="uid://bfgpq3obygaei" path="res://Scripts/story_card.gd" id="1_cxbvt"]
-[ext_resource type="Theme" uid="uid://gtweqjsmt5k" path="res://default_ui_theme.tres" id="2_8h8ol"]
-[ext_resource type="Texture2D" uid="uid://d14eog7ypgap1" path="res://Assets/Sprites/Icons.png" id="3_8h8ol"]
-[ext_resource type="Texture2D" uid="uid://kd7p8hou1dcu" path="res://Assets/Sprites/selected.png" id="4_8h8ol"]
+[ext_resource type="Script" uid="uid://bfgpq3obygaei" path="res://Scripts/story_card.gd" id="1_3jn1p"]
+[ext_resource type="Theme" uid="uid://gtweqjsmt5k" path="res://default_ui_theme.tres" id="2_kttbx"]
+[ext_resource type="Texture2D" uid="uid://d14eog7ypgap1" path="res://Assets/Sprites/Icons.png" id="3_f3fwx"]
+[ext_resource type="Texture2D" uid="uid://kd7p8hou1dcu" path="res://Assets/Sprites/selected.png" id="4_y0yi7"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jjvhh"]
 size = Vector2(126, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_lev7e"]
-atlas = ExtResource("3_8h8ol")
-region = Rect2(800, 0, 200, 200)
+atlas = ExtResource("3_f3fwx")
+region = Rect2(600, 400, 200, 200)
 
-[node name="StoryCard" type="Area2D" groups=["story_card"]]
-script = ExtResource("1_cxbvt")
-body = "[left]No text on this card. Edit body export variable to add text. [/left]"
+[node name="LabElevator" type="Area2D" groups=["story_card"]]
+script = ExtResource("1_3jn1p")
+body = "There was another way into the lab. It wasn't big enough for a person, but it was enough for the supplies Peter needed. The facility had labs on multiple floors and some where connected with a small elevator for quick transfer of samples. Matthew was heading toward the lab that was connected to Maria's.
+
+Inside he quickly found the medicinal alcohol and loaded it into the elevator. As he pressed the button he let out a big sigh but he couldn't relax yet. He hurried back to the guard room and as he got back to watching Peter he had already continued his work. Now Matthew just needed to win time for Peter, he still had quite a lot of it before he would also turn, and as that thought passed through his mind, he saw how the double doors bulged inward from the smashing it received from Sarahs homemade battering ram."
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_jjvhh")
@@ -32,7 +34,7 @@ offset_bottom = 102.5
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
-theme = ExtResource("2_8h8ol")
+theme = ExtResource("2_kttbx")
 
 [node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
 layout_mode = 2
@@ -52,8 +54,7 @@ layout_mode = 2
 size_flags_vertical = 3
 size_flags_stretch_ratio = 3.0
 mouse_filter = 2
-text = "Story Card Template
-"
+text = "Lab Elevator"
 fit_content = true
 horizontal_alignment = 1
 
@@ -79,7 +80,7 @@ mouse_filter = 2
 [node name="SelectedSprite" type="Sprite2D" parent="."]
 position = Vector2(1.19209e-06, 1.49999)
 scale = Vector2(0.71, 1.105)
-texture = ExtResource("4_8h8ol")
+texture = ExtResource("4_y0yi7")
 
 [connection signal="area_entered" from="." to="." method="_on_area_entered"]
 [connection signal="area_exited" from="." to="." method="_on_area_exited"]

--- a/Scenes/StoryCards/matthew_watching.tscn
+++ b/Scenes/StoryCards/matthew_watching.tscn
@@ -1,20 +1,24 @@
-[gd_scene load_steps=7 format=3 uid="uid://da3vfbn325gkk"]
+[gd_scene load_steps=7 format=3 uid="uid://bn61qjgsu8t5t"]
 
-[ext_resource type="Script" uid="uid://bfgpq3obygaei" path="res://Scripts/story_card.gd" id="1_cxbvt"]
-[ext_resource type="Theme" uid="uid://gtweqjsmt5k" path="res://default_ui_theme.tres" id="2_8h8ol"]
-[ext_resource type="Texture2D" uid="uid://d14eog7ypgap1" path="res://Assets/Sprites/Icons.png" id="3_8h8ol"]
-[ext_resource type="Texture2D" uid="uid://kd7p8hou1dcu" path="res://Assets/Sprites/selected.png" id="4_8h8ol"]
+[ext_resource type="Script" uid="uid://bfgpq3obygaei" path="res://Scripts/story_card.gd" id="1_3jn1p"]
+[ext_resource type="Theme" uid="uid://gtweqjsmt5k" path="res://default_ui_theme.tres" id="2_kttbx"]
+[ext_resource type="Texture2D" uid="uid://d14eog7ypgap1" path="res://Assets/Sprites/Icons.png" id="3_f3fwx"]
+[ext_resource type="Texture2D" uid="uid://kd7p8hou1dcu" path="res://Assets/Sprites/selected.png" id="4_y0yi7"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jjvhh"]
 size = Vector2(126, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_lev7e"]
-atlas = ExtResource("3_8h8ol")
-region = Rect2(800, 0, 200, 200)
+atlas = ExtResource("3_f3fwx")
+region = Rect2(400, 800, 200, 200)
 
-[node name="StoryCard" type="Area2D" groups=["story_card"]]
-script = ExtResource("1_cxbvt")
-body = "[left]No text on this card. Edit body export variable to add text. [/left]"
+[node name="MatthewWatching" type="Area2D" groups=["story_card"]]
+script = ExtResource("1_3jn1p")
+body = "Matthews head was spinning as he ran back toward the guard room, Sarah wasn't wrong, a female zombie could birth a slug and a slug could mean the end of the facility. What she didn't seem to understand was that finding a cure could save the whole world, Matthew knew how close Maria had been a breakthrough these last few days. When Matthew got inside the guard room he was sweating profusely and tore of his lab coat and hung it on one of the chairs.
+
+He stared at the screen showing Marias lab. What was going through Peters head? What could he do to help him? All these thoughts raced through Matthews head as he watched but suddenly Peter slammed his fist on the counter and collapsed in a chair. With his head in his hands Peter was crying.
+
+Matthew couldn't tear his eyes away from Peter as his heart sank, was it all over? He zoomed in hos friend in some futile attempt to console him. At that moment Peter looked up as if he understood that someone was watching. He hurried over to another table, grabbed a pen and paper and scribbled a few words on it that he then held up to the camera. \"I'm out of medicinal alcohol, help!\""
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_jjvhh")
@@ -32,7 +36,7 @@ offset_bottom = 102.5
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
-theme = ExtResource("2_8h8ol")
+theme = ExtResource("2_kttbx")
 
 [node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
 layout_mode = 2
@@ -52,8 +56,7 @@ layout_mode = 2
 size_flags_vertical = 3
 size_flags_stretch_ratio = 3.0
 mouse_filter = 2
-text = "Story Card Template
-"
+text = "Matthew Watching"
 fit_content = true
 horizontal_alignment = 1
 
@@ -79,7 +82,7 @@ mouse_filter = 2
 [node name="SelectedSprite" type="Sprite2D" parent="."]
 position = Vector2(1.19209e-06, 1.49999)
 scale = Vector2(0.71, 1.105)
-texture = ExtResource("4_8h8ol")
+texture = ExtResource("4_y0yi7")
 
 [connection signal="area_entered" from="." to="." method="_on_area_entered"]
 [connection signal="area_exited" from="." to="." method="_on_area_exited"]

--- a/Scenes/StoryCards/the_note.tscn
+++ b/Scenes/StoryCards/the_note.tscn
@@ -1,22 +1,26 @@
-[gd_scene load_steps=7 format=3 uid="uid://u11kmbwow0mk"]
+[gd_scene load_steps=7 format=3 uid="uid://b5eoxyjrmjqb"]
 
-[ext_resource type="Script" uid="uid://bfgpq3obygaei" path="res://Scripts/story_card.gd" id="1_rwv74"]
-[ext_resource type="Theme" uid="uid://gtweqjsmt5k" path="res://default_ui_theme.tres" id="2_vtckn"]
-[ext_resource type="Texture2D" uid="uid://d14eog7ypgap1" path="res://Assets/Sprites/Icons.png" id="3_2o54x"]
-[ext_resource type="Texture2D" uid="uid://kd7p8hou1dcu" path="res://Assets/Sprites/selected.png" id="4_6caqq"]
+[ext_resource type="Script" uid="uid://bfgpq3obygaei" path="res://Scripts/story_card.gd" id="1_i1kra"]
+[ext_resource type="Theme" uid="uid://gtweqjsmt5k" path="res://default_ui_theme.tres" id="2_pasrv"]
+[ext_resource type="Texture2D" uid="uid://d14eog7ypgap1" path="res://Assets/Sprites/Icons.png" id="3_4h2a2"]
+[ext_resource type="Texture2D" uid="uid://kd7p8hou1dcu" path="res://Assets/Sprites/selected.png" id="4_vofne"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jjvhh"]
 size = Vector2(126, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_lev7e"]
-atlas = ExtResource("3_2o54x")
-region = Rect2(200, 1000, 200, 200)
+atlas = ExtResource("3_4h2a2")
+region = Rect2(0, 200, 200, 200)
 
-[node name="Story_Card" type="Area2D" groups=["story_card"]]
-script = ExtResource("1_rwv74")
-body = "Peter loved his wife Maria. Loved her for the way she talked, those rolling r’s which was the only thing revealing her accent. The smile she wore even through these dark times and her jokes that could make everyone in the room laugh. He loved the smell of her as he snuggled close to her at night but most of all, right now, he loved her for her brain. 
+[node name="TheNote" type="Area2D" groups=["story_card"]]
+script = ExtResource("1_i1kra")
+body = "Matthew
 
-When they met she was already a brilliant scientist, but the research they had done together for the last three years would never have reached near any of the heights it had if it wasn’t for her. They were so close to a breakthrough and the last two weeks, the work that Maria had done, was what had gotten them to this point."
+I was so close but I didn’t have time synthesize the cure. The instructions are all here. Please help me finish the work. I have locked myself in the bathroom and Maria is in the supply closet. Don’t let them kill us, the cure can save us all.
+
+
+[left]Your friend and collegue[/left]
+Peter"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_jjvhh")
@@ -34,7 +38,7 @@ offset_bottom = 102.5
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
-theme = ExtResource("2_vtckn")
+theme = ExtResource("2_pasrv")
 
 [node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
 layout_mode = 2
@@ -54,7 +58,7 @@ layout_mode = 2
 size_flags_vertical = 3
 size_flags_stretch_ratio = 3.0
 mouse_filter = 2
-text = "Love and Science"
+text = "The Note"
 fit_content = true
 horizontal_alignment = 1
 
@@ -80,7 +84,7 @@ mouse_filter = 2
 [node name="SelectedSprite" type="Sprite2D" parent="."]
 position = Vector2(1.19209e-06, 1.49999)
 scale = Vector2(0.71, 1.105)
-texture = ExtResource("4_6caqq")
+texture = ExtResource("4_vofne")
 
 [connection signal="area_entered" from="." to="." method="_on_area_entered"]
 [connection signal="area_exited" from="." to="." method="_on_area_exited"]

--- a/Scenes/StoryCards/zombie_outbreak.tscn
+++ b/Scenes/StoryCards/zombie_outbreak.tscn
@@ -1,20 +1,25 @@
-[gd_scene load_steps=7 format=3 uid="uid://da3vfbn325gkk"]
+[gd_scene load_steps=7 format=3 uid="uid://cq0amfa6xlaiw"]
 
-[ext_resource type="Script" uid="uid://bfgpq3obygaei" path="res://Scripts/story_card.gd" id="1_cxbvt"]
-[ext_resource type="Theme" uid="uid://gtweqjsmt5k" path="res://default_ui_theme.tres" id="2_8h8ol"]
-[ext_resource type="Texture2D" uid="uid://d14eog7ypgap1" path="res://Assets/Sprites/Icons.png" id="3_8h8ol"]
-[ext_resource type="Texture2D" uid="uid://kd7p8hou1dcu" path="res://Assets/Sprites/selected.png" id="4_8h8ol"]
+[ext_resource type="Script" uid="uid://bfgpq3obygaei" path="res://Scripts/story_card.gd" id="1_apglg"]
+[ext_resource type="Theme" uid="uid://gtweqjsmt5k" path="res://default_ui_theme.tres" id="2_vmxi8"]
+[ext_resource type="Texture2D" uid="uid://d14eog7ypgap1" path="res://Assets/Sprites/Icons.png" id="3_xp8n7"]
+[ext_resource type="Texture2D" uid="uid://kd7p8hou1dcu" path="res://Assets/Sprites/selected.png" id="4_qjo8g"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jjvhh"]
 size = Vector2(126, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_lev7e"]
-atlas = ExtResource("3_8h8ol")
-region = Rect2(800, 0, 200, 200)
+atlas = ExtResource("3_xp8n7")
+region = Rect2(800, 800, 200, 200)
 
-[node name="StoryCard" type="Area2D" groups=["story_card"]]
-script = ExtResource("1_cxbvt")
-body = "[left]No text on this card. Edit body export variable to add text. [/left]"
+[node name="zombie_outbreak" type="Area2D" groups=["story_card"]]
+script = ExtResource("1_apglg")
+body = "Sarah was standing in the guard room in front of the surveillance screens. She wore a spotless dark blue uniform with the guard captain insignia on the left side of her chest. What she was witnessing had her in disbelief, how could it happen, here and now? They had taken every precaution, the rangers were kept in quarantine for twenty four hours when coming back from assignments and the scientists always worked with the proper protection equipment when handling the infected rats.
+
+Sarah swore under her breath and collected her racing thoughts. Even if Maria and Peter were lost to the sickness there where many that could still be saved. By her side stood her life long friend Matthew who was working in the labs together with Maria and Peter, he had stopped by the guard room to share his morning coffee with Sarah as he so often did.
+
+\"Nathaniel, get Rose and Theo and bring shotguns. I'll meet you outside Marias lab\". Nathaniel had the same uniform, not as perfect as Sarahs though, and he wore the standard guard insignia.
+\"Yes, ma'am!\" he answered Sarah and left the room."
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_jjvhh")
@@ -32,7 +37,7 @@ offset_bottom = 102.5
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
-theme = ExtResource("2_8h8ol")
+theme = ExtResource("2_vmxi8")
 
 [node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
 layout_mode = 2
@@ -52,8 +57,7 @@ layout_mode = 2
 size_flags_vertical = 3
 size_flags_stretch_ratio = 3.0
 mouse_filter = 2
-text = "Story Card Template
-"
+text = "Zombie Outbreak"
 fit_content = true
 horizontal_alignment = 1
 
@@ -79,7 +83,7 @@ mouse_filter = 2
 [node name="SelectedSprite" type="Sprite2D" parent="."]
 position = Vector2(1.19209e-06, 1.49999)
 scale = Vector2(0.71, 1.105)
-texture = ExtResource("4_8h8ol")
+texture = ExtResource("4_qjo8g")
 
 [connection signal="area_entered" from="." to="." method="_on_area_entered"]
 [connection signal="area_exited" from="." to="." method="_on_area_exited"]

--- a/Scenes/event_text_controller.tscn
+++ b/Scenes/event_text_controller.tscn
@@ -63,6 +63,9 @@ size_flags_stretch_ratio = 20.0
 theme_override_fonts/normal_font = ExtResource("3_fnanm")
 theme_override_font_sizes/normal_font_size = 12
 bbcode_enabled = true
-text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.d
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+text = "[left]Left click and hold to move cards
+
+The goal is to arrange the cards in chronological order. When all cards are in the correct place, hit the VALIDATE button
+
+Right click to open and read cards to figure out the order of events[/left]"
 horizontal_alignment = 3

--- a/Scenes/main.tscn
+++ b/Scenes/main.tscn
@@ -1,82 +1,17 @@
-[gd_scene load_steps=10 format=3 uid="uid://d4llv7opqcv4p"]
+[gd_scene load_steps=8 format=3 uid="uid://d4llv7opqcv4p"]
 
-[ext_resource type="PackedScene" uid="uid://da3vfbn325gkk" path="res://Scenes/StoryCards/story_card_template.tscn" id="1_jjgbg"]
 [ext_resource type="Script" uid="uid://cxkgkg0ts864s" path="res://Scripts/card_manager.gd" id="2_bo1nx"]
 [ext_resource type="PackedScene" uid="uid://ddyng28usspt6" path="res://Scenes/event_text_controller.tscn" id="3_8gbba"]
-[ext_resource type="Texture2D" uid="uid://d14eog7ypgap1" path="res://Assets/Sprites/Icons.png" id="3_kry3j"]
+[ext_resource type="PackedScene" uid="uid://6bk3cflxuf7g" path="res://Scenes/StoryCards/lab_elevator.tscn" id="4_6bp64"]
 [ext_resource type="Script" uid="uid://bxsr1lvutq7ve" path="res://Scripts/animation_controller.gd" id="4_jjvhh"]
-[ext_resource type="PackedScene" uid="uid://u11kmbwow0mk" path="res://Scenes/StoryCards/love_and_science.tscn" id="6_21xkr"]
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6bp64"]
-atlas = ExtResource("3_kry3j")
-region = Rect2(200, 1200, 200, 200)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_kry3j"]
-atlas = ExtResource("3_kry3j")
-region = Rect2(1000, 0, 200, 200)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_21xkr"]
-atlas = ExtResource("3_kry3j")
-region = Rect2(0, 400, 200, 200)
+[ext_resource type="PackedScene" uid="uid://bn61qjgsu8t5t" path="res://Scenes/StoryCards/matthew_watching.tscn" id="5_344ge"]
+[ext_resource type="PackedScene" uid="uid://b5eoxyjrmjqb" path="res://Scenes/StoryCards/the_note.tscn" id="6_ynf5e"]
+[ext_resource type="PackedScene" uid="uid://cq0amfa6xlaiw" path="res://Scenes/StoryCards/zombie_outbreak.tscn" id="7_hptm8"]
 
 [node name="Main" type="Node2D"]
 
 [node name="Card Manager" type="Node2D" parent="."]
 script = ExtResource("2_bo1nx")
-
-[node name="Story_Card" parent="Card Manager" instance=ExtResource("1_jjgbg")]
-position = Vector2(431, 288)
-body = "Matthew was running back to the surveillance room, head spinning, Sarah wasn’t wrong. A female zombie could birth a slug, and a slug could mean the end of the whole facility, but not finding the cure would mean the end of the whole world. 
-
-He got into the room, closed it and locked it and was looking at the camera. What are you up to old friend, he looked as Peter was working at his counter. Suddenly he stopped and collapsed on a chair. Peter looked distraught, like the air going out of a balloon. 
-
-What had happened in there? Matthew took manual control of the camera and zoomed in on his colleague and close friend. He could see him breathe heavily, eyes at the floor with tears and sweat trickling down his face. Then he suddenly looked up, realising something, and he locked eyes with Matthew through the camera. 
-
-Matthew knew that Peter understood that it was him watching, that he would be more interested in what was going on in there than outside with Sarah and the other guards. He then ran over to another table, scribbled on a piece of paper that he then held up towards the camera “I need medical alchohol, Saiprotine and a bunsen burner, fast!”"
-
-[node name="CardHeader" parent="Card Manager/Story_Card/PanelContainer/MarginContainer/VBoxContainer" index="0"]
-text = "Matthew Watching"
-
-[node name="TextureRect" parent="Card Manager/Story_Card/PanelContainer/MarginContainer/VBoxContainer" index="2"]
-texture = SubResource("AtlasTexture_6bp64")
-
-[node name="Story_Card4" parent="Card Manager" instance=ExtResource("1_jjgbg")]
-position = Vector2(184, 271)
-body = "Matthew ran through the facility once again. Now headed for another supply closet where they stored medicine of different kinds. After rummaging through the contents of the shelves with a feverish intensity he found what he was looking for: a tranquilizer. 
-
-He grabbed a flask and concocted a sleeping draught within it, masking the tranquilizers taste with some alcohol and lemon juice – Sarahs favorite cocktail was the Gold Rush and although this was just a weak imitation maybe it would be enough for her to drink. 
-
-He ran back to the lab where he heard crashing sound after crashing sound of the battering ram smashing against the doors.  "
-
-[node name="CardHeader" parent="Card Manager/Story_Card4/PanelContainer/MarginContainer/VBoxContainer" index="0"]
-text = "Planning Betrayal"
-
-[node name="TextureRect" parent="Card Manager/Story_Card4/PanelContainer/MarginContainer/VBoxContainer" index="2"]
-texture = SubResource("AtlasTexture_kry3j")
-
-[node name="Story_Card2" parent="Card Manager" instance=ExtResource("1_jjgbg")]
-position = Vector2(447, 76)
-body = "Matthew
-
-I was so close but I didn’t have time synthesize the cure. The instructions are all here. Please help me finish the work. I have locked myself in the bathroom and Maria is in the supply closet. Don’t let them kill us, the cure can save us all.
-
-[left]Your friend and colleague[/left]
-Peter"
-
-[node name="CardHeader" parent="Card Manager/Story_Card2/PanelContainer/MarginContainer/VBoxContainer" index="0"]
-text = "The Note"
-
-[node name="TextureRect" parent="Card Manager/Story_Card2/PanelContainer/MarginContainer/VBoxContainer" index="2"]
-texture = SubResource("AtlasTexture_21xkr")
-
-[node name="Story_Card3" parent="Card Manager" instance=ExtResource("1_jjgbg")]
-position = Vector2(335, 510)
-body = "Peter was working at his station as Maria came up behind him, putting her arms around him, laying her cheek flat against his upper back. She reached up and kissed him on the neck and a familiar tingling spread up his head and nestled in the roots of his hair. “I love you” he said and she murmured the same back to him. 
-
-Then he felt a sudden jolt of pain as Maria sunk her teeth into his neck. Instinctively he thrust his elbow back, pushing her off of him but he felt the skin rip and as he turned around a flap of flesh hung from her gritted teeth. He grabbed his labcoat just to have something to shield himself with and she lunged for him with animalistic ferocity. She had turned, how the hell had she turned!?"
-
-[node name="CardHeader" parent="Card Manager/Story_Card3/PanelContainer/MarginContainer/VBoxContainer" index="0"]
-text = "The Bite"
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
@@ -91,11 +26,16 @@ fit_content = true
 [node name="AnimationController" type="Node" parent="."]
 script = ExtResource("4_jjvhh")
 
-[node name="Story_Card" parent="." instance=ExtResource("6_21xkr")]
-position = Vector2(552, 499)
+[node name="LabElevator" parent="." instance=ExtResource("4_6bp64")]
+position = Vector2(234, 190)
 
-[editable path="Card Manager/Story_Card"]
-[editable path="Card Manager/Story_Card4"]
-[editable path="Card Manager/Story_Card2"]
-[editable path="Card Manager/Story_Card3"]
+[node name="MatthewWatching" parent="." instance=ExtResource("5_344ge")]
+position = Vector2(389, 188)
+
+[node name="TheNote" parent="." instance=ExtResource("6_ynf5e")]
+position = Vector2(539, 197)
+
+[node name="zombie_outbreak" parent="." instance=ExtResource("7_hptm8")]
+position = Vector2(81, 181)
+
 [editable path="CanvasLayer/EventTextController"]


### PR DESCRIPTION
There are now four starting events that need to be put into chronological order.

I have also removed an old event that I used for testing

Simple game instructions added to the event_text_controller default text.